### PR TITLE
Chaining joins DSL

### DIFF
--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -1,0 +1,27 @@
+name: pg-idris example project
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build_example:
+    runs-on: ubuntu-latest
+    container: mattpolzin2/idris-docker:nightly
+
+    env:
+      IDRIS2_CG: chez
+
+    steps:
+      - name: Install Dependencies
+        run: apt-get update && apt-get -y install git libpq-dev libpq5 libc6-dev
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build pg-idris
+        run: make && make install
+      - name: Build example project
+        run: |
+          cd Example
+          make build
+

--- a/Example/Main.idr
+++ b/Example/Main.idr
@@ -62,7 +62,7 @@ functionsTable = PT "pg_proc" [ ("proname", col NonNullable PString)
 
 showFunctions : Connection -> IO ()
 showFunctions conn = do
-  Right (_ ** rows) <- tableQuery functionsTable [("proname", String), ("proargnames", Maybe (List String))] conn
+  Right (_ ** rows) <- tableQuery' functionsTable [("proname", String), ("proargnames", Maybe (List String))] conn
     | Left err => putStrLn err
   for_ rows $ \(name :: args :: []) => do
     putStrLn $ name ++ "(" ++ (join ", " (maybe [] id args)) ++ ")"

--- a/README.md
+++ b/README.md
@@ -226,9 +226,18 @@ table2 = pgTable "second_table" [
 , ("location"      , NonNullable, PString)
 ]
 
+-- infix notation:
 execJoin : Database ? Open (const Open)
 execJoin = exec $
-  DB.tableQuery (innerJoin table1 table2 ("id" == "first_table_id"))
+  DB.tableQuery (table1 `innerJoin` table2 `onColumns` ("id" == "first_table_id"))
+                [ ("first_table.name"     , String)
+                , ("second_table.location", String)
+                ]
+
+-- prefix notation:
+execJoin' : Database ? Open (const Open)
+execJoin' = exec $
+  DB.tableQuery (innerJoin' table1 table2 ("id" == "first_table_id"))
                 [ ("first_table.name"     , String)
                 , ("second_table.location", String)
                 ]
@@ -238,9 +247,20 @@ You can create table aliases within statements. An example left-join including t
 ```idris
 execJoin2 : Database ? Open (const Open)
 execJoin2 = exec $
-  DB.tableQuery (leftJoin (table1 `as` "t") (table2 `as` "o") ("id" == "first_table_id"))
+  DB.tableQuery ((table1 `as` "t") `leftJoin` (table2 `as` "o") `onColumns` ("id" == "first_table_id"))
                 [ ("t.name"    , String)
                 , ("o.location", Maybe String)
                 ]
 ```
 
+Although you have to get certain details right (namely, put parens around the column equality, use table names anywhere past the first column equality), the infix notation is fairly legible even for multiple joins:
+```idris
+execJoin3 : Database ? Open (const Open)
+execJoin3 = exec $
+  DB.tableQuery (table1 `innerJoin` table2 `onColumns` ("id" == "first_table_id")
+                        `leftJoin`  (table2 `as` "third_table") `onColumns` ("first_table.id" == "third_table.first_table_id"))
+                [ ("first_table.name"     , String)
+                , ("second_table.location", String)
+                , ("third_table.location" , Maybe String)
+                ]
+```

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ execSelect = exec $
 
 Notice that for `tableQuery` the table name must be given in addition to the column name. The ability to specify the table name will come in handing when writing queries against statements with subqueries or joins, but here it feels unnecessary. There is a `tableQuery'` function that accepts just the column names for simple queries against single tables where no column name conflict is possible.
 
-You can also select results out of table joins (currently only inner-joins and left-joins):
+You can also select results out of table joins (currently only inner-, right-, and left-joins):
 ```idris
 table2 : PersistedTable
 table2 = pgTable "second_table" [

--- a/pg-idris.ipkg
+++ b/pg-idris.ipkg
@@ -3,7 +3,7 @@ authors = "Mathew Polzin"
 license = "MIT"
 brief = "Postgres support for Idris 2 programs compiled with the Chez Scheme or NodeJS backends."
 
-version = 0.0.5
+version = 0.0.6
 langversion >= 0.6.0
 
 sourcedir = "src"
@@ -30,6 +30,6 @@ modules = Postgres
 depends = contrib >= 0.6.0
         , indexed >= 0.0.9
 
-prebuild = "TARGET_VERSION=0.0.5 make -C support"
-postinstall = "TARGET_VERSION=0.0.5 make -C support install"
-postclean = "TARGET_VERSION=0.0.5 make -C support clean"
+prebuild = "TARGET_VERSION=0.0.6 make -C support"
+postinstall = "TARGET_VERSION=0.0.6 make -C support install"
+postclean = "TARGET_VERSION=0.0.6 make -C support clean"

--- a/src/Postgres/Data/PostgresTable.idr
+++ b/src/Postgres/Data/PostgresTable.idr
@@ -330,7 +330,7 @@ elemForOnMapping table c (Right (_, m)) = (replaceSource (aliasOrName table) c *
 ||| a shared column. In pseudo-code: "table1 join table2 'on' col1 = col2".
 |||
 ||| ```idris example
-||| innerJoin table1 table2 ("col_from_table1" == "col_from_table2")
+||| innerJoin' table1 table2 ("col_from_table1" == "col_from_table2")
 ||| ```
 public export
 (==) : PostgresTable t => PostgresTable u => {t1 : t} -> {t2 : u} -> (c1 : ColumnIdentifier) -> (c2 : ColumnIdentifier) -> {auto on1 : HasOnMapping c1 t1} -> {auto on2 : HasOnMapping c2 t2} -> Join t1 t2
@@ -346,13 +346,13 @@ namespace Join
   column2 : Join t u -> ColumnIdentifier
   column2 (On c1 c2) = c2
 
-||| Construct a runtime table by joining two other tables on a specified column.
+||| Construct a runtime table by inner-joining two other tables on a specified column.
 |||
 ||| ```idris example
 ||| innerJoin' table1 table2 ("col_from_table1" == "col_from_table2")
 ||| ```
 public export
-innerJoin' : {0 t : _} -> (table1 : t) -> PostgresTable t => {0 u : _} -> (table2 : u) -> PostgresTable u => (on : Join table1 table2) -> RuntimeTable
+innerJoin' : PostgresTable t => (table1 : t) -> PostgresTable u => (table2 : u) -> (on : Join table1 table2) -> RuntimeTable
 innerJoin' table1 table2 joinOn = 
   let table1Statement = show $ tableStatement table1
       table2Statement = show $ tableStatement table2
@@ -363,13 +363,13 @@ innerJoin' table1 table2 joinOn =
       table2Cols = columns table2
   in  RT (Fragment subquery) (table1Cols ++ table2Cols)
 
-||| Construct a runtime table by inner-joining two other tables on a specified column.
+||| Construct a runtime table by left-joining two other tables on a specified column.
 |||
 ||| ```idris example
 ||| leftJoin' table1 table2 ("col_from_table1" == "col_from_table2")
 ||| ```
 public export 
-leftJoin' : {0 t : _} -> (table1 : t) -> PostgresTable t => ({0 u : _} -> (table2 : u) -> PostgresTable u => (on : Join table1 table2) -> RuntimeTable)
+leftJoin' : PostgresTable t => (table1 : t) -> PostgresTable u => (table2 : u) -> (on : Join table1 table2) -> RuntimeTable
 leftJoin' table1 table2 joinOn =
   let table1Statement = show $ tableStatement table1
       table2Statement = show $ tableStatement table2
@@ -381,30 +381,65 @@ leftJoin' table1 table2 joinOn =
       -- ^ need to make table2's columns possibly null because of the left-join.
   in  RT (Fragment subquery) (table1Cols ++ table2Cols)
 
+||| Construct a runtime table by right-joining two other tables on a specified column.
+|||
+||| ```idris example
+||| rightJoin' table1 table2 ("col_from_table1" == "col_from_table2")
+||| ```
+public export 
+rightJoin' : PostgresTable t => (table1 : t) -> PostgresTable u => (table2 : u) -> (on : Join table1 table2) -> RuntimeTable
+rightJoin' table1 table2 joinOn =
+  let table1Statement = show $ tableStatement table1
+      table2Statement = show $ tableStatement table2
+      table1JoinName = show $ column1 joinOn
+      table2JoinName = show $ column2 joinOn
+      subquery = "\{table1Statement} LEFT JOIN \{table2Statement} ON \{table1JoinName} = \{table2JoinName}"
+      table1Cols = mapSnd (bimap (\t => t) makeNullable) <$> columns table1
+      -- ^ need to make table1's columns possibly null because of the right-join.
+      table2Cols = columns table2
+  in  RT (Fragment subquery) (table1Cols ++ table2Cols)
 
 public export
-data JoinType = Inner | Left
+data JoinType = Inner | Left | Right
 
 public export
 data TablePair : table1 -> table2 -> Type where
   MkTP : JoinType -> PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
 
 ||| Inner-join two tables.
+||| This produces a pair of tables and a join strategy. You then need to use `onColumns` to take the table pair
+||| and add the columns that the join should occur over.
 public export
 innerJoin : PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
 innerJoin = MkTP Inner
 
-||| Inner-join two tables.
+||| Left-join two tables.
+||| This produces a pair of tables and a join strategy. You then need to use `onColumns` to take the table pair
+||| and add the columns that the join should occur over.
 public export
 leftJoin : PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
 leftJoin = MkTP Left
 
+||| Right-join two tables.
+||| This produces a pair of tables and a join strategy. You then need to use `onColumns` to take the table pair
+||| and add the columns that the join should occur over.
+public export
+rightJoin : PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
+rightJoin = MkTP Right
+
+||| Given that you've already paired two tables up (see `innerJoin`, `leftJoin`, `rightJoin`)
+||| you use `onColumns` to specify which columns from each table in the pair should be equal
+||| in the joined table. The end result is a new table.
+|||
+||| Psuedo-example:
+|||   table1 `innerJoin` table2 `onColumns` ("table1.col1" == "table2.col2")
 public export
 onColumns : TablePair table1 table2 -> Join table1 table2 -> RuntimeTable
 onColumns (MkTP Inner table1 table2) joinOn = innerJoin' table1 table2 joinOn
 onColumns (MkTP Left table1 table2) joinOn = leftJoin' table1 table2 joinOn
+onColumns (MkTP Right table1 table2) joinOn = rightJoin' table1 table2 joinOn
 
-infixl 10 `innerJoin`, `leftJoin`, `onColumns`
+infixl 10 `innerJoin`, `leftJoin`, `rightJoin`, `onColumns`
 
 mappingCastable : {cs : _} -> ColumnMapping IdrCast cs (ident, ty) => Castable ty
 mappingCastable {cs = ((ident, Evidence pt (MkColType Nullable pt)) :: xs)} @{(HereNul ident x @{sc})} = CastMaybe @{IdrCastString {pt}}

--- a/src/Postgres/Data/PostgresTable.idr
+++ b/src/Postgres/Data/PostgresTable.idr
@@ -389,17 +389,22 @@ public export
 data TablePair : table1 -> table2 -> Type where
   MkTP : JoinType -> PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
 
-infixl 10 `innerJoin`, `on`
-
 ||| Inner-join two tables.
 public export
 innerJoin : PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
 innerJoin = MkTP Inner
 
+||| Inner-join two tables.
 public export
-on : TablePair table1 table2 -> Join table1 table2 -> RuntimeTable
-on (MkTP Inner table1 table2) joinOn = innerJoin' table1 table2 joinOn
-on (MkTP Left table1 table2) joinOn = leftJoin' table1 table2 joinOn
+leftJoin : PostgresTable t => PostgresTable u => (table1 : t) -> (table2 : u) -> TablePair table1 table2
+leftJoin = MkTP Left
+
+public export
+onColumns : TablePair table1 table2 -> Join table1 table2 -> RuntimeTable
+onColumns (MkTP Inner table1 table2) joinOn = innerJoin' table1 table2 joinOn
+onColumns (MkTP Left table1 table2) joinOn = leftJoin' table1 table2 joinOn
+
+infixl 10 `innerJoin`, `leftJoin`, `onColumns`
 
 mappingCastable : {cs : _} -> ColumnMapping IdrCast cs (ident, ty) => Castable ty
 mappingCastable {cs = ((ident, Evidence pt (MkColType Nullable pt)) :: xs)} @{(HereNul ident x @{sc})} = CastMaybe @{IdrCastString {pt}}

--- a/support/Makefile
+++ b/support/Makefile
@@ -2,7 +2,7 @@
 IDRIS := idris2
 
 TARGET = libpg-idris
-TARGET_VERSION ?= 0.0.5
+TARGET_VERSION ?= 0.0.6
 
 INSTALLDIR = `${IDRIS} --libdir`/pg-idris-${TARGET_VERSION}
 LIBDIR = "${INSTALLDIR}/lib"

--- a/tests/alias_query/AliasQuery.idr
+++ b/tests/alias_query/AliasQuery.idr
@@ -73,7 +73,7 @@ main =
     liftIO' . putStrLn $ show res21
     res22 <- exec $ perform setupQuery22
     liftIO' . putStrLn $ show res22
-    Right (rows ** res3) <- exec $ tableQuery (leftJoin (table1 `as` "t") (table2 `as` "o") (on "t.i" "o.f_i") `as` "out") testQuery
+    Right (rows ** res3) <- exec $ tableQuery (leftJoin' (table1 `as` "t") (table2 `as` "o") ("t.i" == "o.f_i") `as` "out") testQuery
       | Left err => liftIO' $ putStrLn err
     liftIO' . for_ res3 $ putStrLn . show
 

--- a/tests/alias_statement/AliasStatement.idr
+++ b/tests/alias_statement/AliasStatement.idr
@@ -16,11 +16,17 @@ table2 = PT "table2" [
 
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query1 = tableQuery
-           (innerJoin (table1 `as` "t") (table2 `as` "o") (on "t.id" "o.f_id"))
+           (innerJoin' (table1 `as` "t") (table2 `as` "o") ("t.id" == "o.f_id"))
            [("t.field1", Double), ("o.field2", Maybe String)]
 
+-- now with infix functions
+query1' : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
+query1' = tableQuery 
+            ((table1 `as` "t") `innerJoin` (table2 `as` "o") `onColumns` ("t.id" == "o.f_id"))
+            [("t.field1", Double), ("o.field2", Maybe String)]
+
 joinedTables : RuntimeTable
-joinedTables = innerJoin table1 table2 (on "table1.id" "table2.f_id") `as` "hello"
+joinedTables = innerJoin' table1 table2 ("table1.id" == "table2.f_id") `as` "hello"
 
 query2 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query2 = tableQuery (joinedTables `as` "new") [("new.field1", Double), ("new.field2", Maybe String)]

--- a/tests/inner_join_query/JoinQuery.idr
+++ b/tests/inner_join_query/JoinQuery.idr
@@ -69,7 +69,7 @@ main =
     liftIO' . putStrLn $ show res20
     res21 <- exec $ perform setupQuery21
     liftIO' . putStrLn $ show res21
-    Right (rows ** res3) <- exec $ tableQuery (innerJoin table1 table2 (on "i" "f_i")) testQuery
+    Right (rows ** res3) <- exec $ tableQuery (innerJoin' table1 table2 ("i" == "f_i")) testQuery
       | Left err => liftIO' $ putStrLn err
     liftIO' . for_ res3 $ putStrLn . show
 

--- a/tests/inner_join_statement/JoinStatement.idr
+++ b/tests/inner_join_statement/JoinStatement.idr
@@ -16,45 +16,39 @@ table2 = PT "table2" [
 
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query1 = tableQuery
-           (innerJoin table1 table2 (On "table1.id" "table2.f_id"))
+           (innerJoin' table1 table2 (On "table1.id" "table2.f_id"))
            [("table1.field1", Double), ("table2.field2", Maybe String)]
 
 -- now with (==) `on` function:
 query2 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query2 = tableQuery
-           (innerJoin table1 table2 ("table1.id" == "table2.f_id"))
+           (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
            [("table1.field1", Double), ("table2.field2", Maybe String)]
 
 -- now with (==) `on` and no table references function:
 query2' : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query2' = tableQuery
-            (innerJoin table1 table2 ("id" == "f_id"))
+            (innerJoin' table1 table2 ("id" == "f_id"))
             [("table1.field1", Double), ("table2.field2", Maybe String)]
 
--- now with lower-case `on` function:
+-- now with infix `innerJoin` and `on`:
 query2'' : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query2'' = tableQuery
-             (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (table1 `innerJoin` table2 `onColumns` ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.field2", Maybe String)]
-
--- and finally without referencing the tables explicitly with lower-case `on` function:
-query2''' : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
-query2''' = tableQuery
-              (innerJoin table1 table2 (on "id" "f_id"))
-              [("table1.field1", Double), ("table2.field2", Maybe String)]
 
 failing
   query3 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query3 = tableQuery
-             (innerJoin table1 table2 (on "table1.id" "table2.problem"))
-             --                                   ^
+             (innerJoin' table1 table2 ("table1.id" == "table2.problem"))
+             --                                                 ^
              -- Can't find "problem" in column names for table2
              [("table1.field1", Double), ("table2.field2", Maybe String)]
 
 failing
   query4 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query4 = tableQuery
-             (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.problem", Maybe String)]
              --                       ^
              -- Can't find "problem" in (innerJoin table1 table2 (on "id" "f_id"))
@@ -62,7 +56,7 @@ failing
 failing
   query5 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query5 = tableQuery
-             (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.field2", String)]
              --                               ^
              -- Can't cast nullable Postgres string to Idris String (should be Maybe String)
@@ -72,6 +66,6 @@ IdrCast PDouble Integer where
 
 query6 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Integer, Maybe String])))
 query6 = tableQuery
-           (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
+           (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
            [("table1.field1", Integer), ("table2.field2", Maybe String)]
 

--- a/tests/left_join_query/JoinQuery.idr
+++ b/tests/left_join_query/JoinQuery.idr
@@ -73,7 +73,7 @@ main =
     liftIO' . putStrLn $ show res21
     res22 <- exec $ perform setupQuery22
     liftIO' . putStrLn $ show res22
-    Right (rows ** res3) <- exec $ tableQuery (leftJoin table1 table2 (on "table1.i" "table2.f_i")) testQuery
+    Right (rows ** res3) <- exec $ tableQuery (leftJoin' table1 table2 ("table1.i" == "table2.f_i")) testQuery
       | Left err => liftIO' $ putStrLn err
     liftIO' . for_ res3 $ putStrLn . show
 

--- a/tests/left_join_statement/LeftJoinStatement.idr
+++ b/tests/left_join_statement/LeftJoinStatement.idr
@@ -17,19 +17,25 @@ table2 = PT "table2" [
 
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query1 = tableQuery
-           (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+           (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
            [("table1.field1", Double), ("table2.field2", Maybe String)]
 
 query2 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
 query2 = tableQuery
-           (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+           (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
            [("table1.field1", Double), ("table2.field3", Maybe String)]
 --                                 ^ was NomNullable in original table, but nullable now because of left join
+
+-- now with infix functions:
+query2' : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String])))
+query2' = tableQuery
+           (table1 `leftJoin` table2 `onColumns` ("table1.id" == "table2.f_id"))
+           [("table1.field1", Double), ("table2.field3", Maybe String)]
 
 failing
   query3 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query3 = tableQuery
-             (leftJoin table1 table2 (on "table1.id" "table2.problem"))
+             (leftJoin' table1 table2 ("table1.id" == "table2.problem"))
              --                                               ^
              -- Can't find "problem" in column names for table2
              [("table1.field1", Double), ("table2.field2", Maybe String)]
@@ -37,7 +43,7 @@ failing
 failing
   query4 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query4 = tableQuery
-             (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.problem", Maybe String)]
              --                                    ^
              -- Can't find "problem" in (innerJoin table1 table2 (on "id" "f_id"))
@@ -45,7 +51,7 @@ failing
 failing
   query5 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query5 = tableQuery
-             (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.field2", String)]
              --                                    ^
              -- Can't cast nullable Postgres string to Idris String (should be Maybe String)
@@ -53,14 +59,14 @@ failing
 failing
   query6 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
   query6 = tableQuery
-             (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+             (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
              [("table1.field1", Double), ("table2.field3", String)]
              --                               ^
              -- Can't cast nullable Postgres string to Idris String (should be Maybe String)
 
 query6' : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
 query6' = tableQuery
-            (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
+            (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
             [("table1.field1", Double), ("table2.field3", String)]
             --                                ^
             -- Failed to select non-nullable String with leftJoin for query6 but succeeds with innerJoin
@@ -71,6 +77,6 @@ IdrCast PDouble Integer where
 
 query7 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Integer, Maybe String])))
 query7 = tableQuery
-           (leftJoin table1 table2 (on "table1.id" "table2.f_id"))
+           (leftJoin' table1 table2 ("table1.id" == "table2.f_id"))
            [("table1.field1", Integer), ("table2.field2", Maybe String)]
 

--- a/tests/pg-idris-tests.ipkg
+++ b/tests/pg-idris-tests.ipkg
@@ -8,5 +8,5 @@ main = Main
 
 depends = contrib >= 0.6.0
         , indexed >= 0.0.9
-        , pg-idris == 0.0.5
+        , pg-idris == 0.0.6
         , test >= 0.6.0

--- a/tests/print_alias_statement/AliasStatement.idr
+++ b/tests/print_alias_statement/AliasStatement.idr
@@ -38,11 +38,11 @@ testQuery = [
 -- we'll test the query compiles and then dump the select string value in the main function to compare golden values
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount ?))
 query1 = tableQuery
-           (leftJoin (table1 `as` "t") (table2 `as` "o") (on "t.i" "o.f_i") `as` "out")
+           (leftJoin' (table1 `as` "t") (table2 `as` "o") ("t.i" == "o.f_i") `as` "out")
            testQuery
 
 main : IO ()
 main = do
   putStrLn "lots of alias in select statement: "
-  putStrLn $ select (leftJoin (table1 `as` "t") (table2 `as` "o") (on "t.i" "o.f_i") `as` "out") testQuery
+  putStrLn $ select (leftJoin' (table1 `as` "t") (table2 `as` "o") ("t.i" == "o.f_i") `as` "out") testQuery
 

--- a/tests/print_double_join_statement/DoubleJoinStatement.idr
+++ b/tests/print_double_join_statement/DoubleJoinStatement.idr
@@ -21,10 +21,18 @@ table3 = PT "table3" [
   ]
 
 doubleJoin : RuntimeTable
-doubleJoin = (innerJoin
-               (innerJoin table1 table3 (on "id" "f_id"))
-               table2 (on "table1.id" "f_id")
+doubleJoin = (innerJoin'
+               (innerJoin' table1 table3 ("id" == "f_id"))
+               table2 ("table1.id" == "f_id")
              )
+
+-- now with infix functions
+doubleJoin' : RuntimeTable
+doubleJoin' = table1 `innerJoin` table3 `onColumns` ("id" == "f_id")
+                     `innerJoin` table2 `onColumns` ("table1.id" == "f_id")
+
+assertEqualResults : Main.doubleJoin = Main.doubleJoin'
+assertEqualResults = Refl
 
 -- we'll test the query compiles and then dump the select string value in the main function to compare golden values
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String, String])))

--- a/tests/print_left_and_inner_join_statements/LeftAndInnerJoinStatements.idr
+++ b/tests/print_left_and_inner_join_statements/LeftAndInnerJoinStatements.idr
@@ -21,10 +21,17 @@ table3 = PT "table3" [
   ]
 
 doubleJoin : RuntimeTable
-doubleJoin = (leftJoin
-               (innerJoin table1 table2 (on "table1.id" "table2.f_id"))
-               table3 (on "table1.id" "table3.f_id")
+doubleJoin = (leftJoin'
+               (innerJoin' table1 table2 ("table1.id" == "table2.f_id"))
+               table3 ("table1.id" == "table3.f_id")
              )
+
+doubleJoin' : RuntimeTable
+doubleJoin' = table1 `innerJoin` table2 `onColumns` ("table1.id" == "table2.f_id")
+                     `leftJoin`  table3 `onColumns` ("table1.id" == "table3.f_id")
+
+assertEqualResults : Main.doubleJoin = Main.doubleJoin'
+assertEqualResults = Refl
 
 query1 : Connection -> IO (Either String (rowCount ** Vect rowCount (HVect [Double, Maybe String, Maybe String])))
 query1 = tableQuery


### PR DESCRIPTION
*Breaking*
- Renamed existing `innerJoin` to `innerJoin'` and `leftJoin` to `leftJoin'` to make way for new infix chainable functions with the old names.
- Old `on` function removed (use `"col1" == "col2"` in place of `on "col1" "col2"`). A new function named `onColumns` is introduced with a very different purpose to facilitate chaining DSL.