### PR TITLE
Move to ilex-json

### DIFF
--- a/pg-idris.ipkg
+++ b/pg-idris.ipkg
@@ -27,7 +27,8 @@ modules = Postgres
         , Postgres.Result
 
 depends = indexed >= 0.0.10
-        , parser-json
+        , ilex-json
+        , contrib
 
 prebuild = "TARGET_VERSION=0.0.8 make -C support"
 postinstall = "TARGET_VERSION=0.0.8 make -C support install"

--- a/src/Postgres/Data/PostgresValue.idr
+++ b/src/Postgres/Data/PostgresValue.idr
@@ -4,6 +4,7 @@ import Data.Either
 import Data.String
 import Data.List
 import Data.List1
+import Data.String.Extra
 import Postgres.Data.PostgresType
 import JSON.Parser
 
@@ -156,10 +157,8 @@ PGCast POid Integer where
 parseArray : String -> Maybe (List String)
 parseArray str = 
   let stripped = trim str
-  in
-      do guard (("{" `isPrefixOf` stripped) && ("}" `isSuffixOf` stripped))
-         let middle = reverse . (drop 1) . reverse . (drop 1) $ unpack stripped
-         pure . forget $ pack <$> (splitOn ',' middle)
+  in do guard (("{" `isPrefixOf` stripped) && ("}" `isSuffixOf` stripped))
+        pure $ forget $ split ((==) ',') (shrink 1 str)
 
 export
 IdrCast from to => IdrCast (PArray from) (List to) where


### PR DESCRIPTION
parser-json now loudly announces it is deprecated and to use ilex-json instead.

This broke array parsing with a weird error and I didn't like the inefficiency of the existing code so I made it better while i was fixing it.